### PR TITLE
Kylie: Flip long 2nd level submenus

### DIFF
--- a/kylie/assets/list-menu.css
+++ b/kylie/assets/list-menu.css
@@ -87,6 +87,11 @@
   transform: translateY(0) translateX(20px);
 }
 
+.list-menu--horizontal .list-submenu .list-submenu--bottom {
+  top: initial;
+  bottom: 0;
+}
+
 .list-menu--horizontal .list-menu__item:hover > .list-submenu {
   visibility: visible;
   pointer-events: all;

--- a/kylie/assets/menus.js
+++ b/kylie/assets/menus.js
@@ -1,0 +1,15 @@
+const triggers = document.querySelectorAll(".list-menu__item:has(.list-submenu)");
+
+const handleMeasure = (e) => {
+  const submenu = e.target.querySelector(".list-submenu");
+
+  const { y, height } = submenu.getBoundingClientRect();
+
+  if (y + height > window.innerHeight) {
+    submenu.classList.add("list-submenu--bottom");
+  }
+};
+
+triggers.forEach((trigger) => {
+  trigger.addEventListener("mouseenter", handleMeasure);
+});

--- a/kylie/layout/theme.liquid
+++ b/kylie/layout/theme.liquid
@@ -89,6 +89,7 @@
   <script src="{{ "focus-point.min.js" | asset_url }}" defer></script>
   <script src="{{ "index.js" | asset_url }}" defer></script>
   <script src="{{ "carousels.js" | asset_url }}" defer></script>
+  <script src="{{ "menus.js" | asset_url }}" defer></script>
 
   {{ content_for_body }}
 


### PR DESCRIPTION
## Description
One of our customers reported that long 2nd level menus can't be fully visible on the page when the parent menu item order is high and viewport height is not so big. This PR fixes that by adding small script which measures the submenu when it's appeared and if the submenu height + y offset are greater then the viewport height then we are anchoring it to the bottom of the parent menu item and setting direction to top (we were anchoring it to the top and positioning to the bottom before)

## External links
Resolves SHOP-302

## Media
![image](https://user-images.githubusercontent.com/32096016/216978024-66088fca-c501-4f8e-9bb9-55183f48951a.png)
![image](https://user-images.githubusercontent.com/32096016/216978039-f6913959-2e48-41b2-b2ce-26c670c4abe6.png)
